### PR TITLE
Upgrade NodeJS runtime for mailer to v10

### DIFF
--- a/infrastructure/bookkeeper.tf
+++ b/infrastructure/bookkeeper.tf
@@ -103,7 +103,7 @@ resource "aws_lambda_function" "bookkeeper-mailer" {
   function_name = "bookkeeper-mailer"
   role          = aws_iam_role.iam_for_lambda.arn
   handler       = "mailgun.handler"
-  runtime       = "nodejs8.10"
+  runtime       = "nodejs10.x"
   timeout       = 5
 
   environment {


### PR DESCRIPTION
AWS is deprecating the Node.js 8.10 runtime because it will reach EOL end of 2019.